### PR TITLE
Factor in bottom safe area when showing keyboard

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
@@ -185,6 +185,7 @@ namespace MvvmCross.Platforms.Ios.Views
             }
             else
             {
+                keyboardFrame.Height -= scrollView.SafeAreaInsets.Bottom;
                 scrollView.CenterView(activeView, keyboardFrame);
             }
         }

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using CoreGraphics;
 using Foundation;
+using MvvmCross.Platforms.Ios;
 using MvvmCross.ViewModels;
 using UIKit;
 
@@ -15,6 +16,9 @@ namespace MvvmCross.Platforms.Ios.Views
 	/// </summary>
 	public abstract class MvxBaseViewController<TViewModel> : MvxViewController where TViewModel : IMvxViewModel
     {
+    
+        private readonly MvxIosMajorVersionChecker _iosVersion11Checker = new MvxIosMajorVersionChecker(11);
+    
         public MvxBaseViewController()
         {
         }
@@ -185,7 +189,8 @@ namespace MvvmCross.Platforms.Ios.Views
             }
             else
             {
-                keyboardFrame.Height -= scrollView.SafeAreaInsets.Bottom;
+                if (_iosVersion11Checker.IsVersionOrHigher)
+                    keyboardFrame.Height -= scrollView.SafeAreaInsets.Bottom;
                 scrollView.CenterView(activeView, keyboardFrame);
             }
         }

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
@@ -16,7 +16,6 @@ namespace MvvmCross.Platforms.Ios.Views
 	/// </summary>
 	public abstract class MvxBaseViewController<TViewModel> : MvxViewController where TViewModel : IMvxViewModel
     {
-    
         private readonly MvxIosMajorVersionChecker _iosVersion11Checker = new MvxIosMajorVersionChecker(11);
     
         public MvxBaseViewController()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

If your scrollview uses is adjusted for the safe area and you use the MvxBaseViewController to adjust the scrollview automatically when showing the keyboard, there will be a gap above the keyboard when it is shown.

### :new: What is the new behavior (if this is a feature change)?

Factors in the safe area inset when adjusting the scrollview. This removes the gap.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
